### PR TITLE
Fix issue with setup failure being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ansible cruft
 *.retry
 *.swp
+# Dropped during CI tests
+tests/ansible.cfg
+tests/roles/cevich.subscribed/
 # Downloaded during CI tests
 .travis_typo_check.sh
 tests/test_vault.yml

--- a/.travis.sh
+++ b/.travis.sh
@@ -74,7 +74,7 @@ do
 done
 
 echo "Testing functionality"
-ansible-playbook -i inventory test.yml
+ansible-playbook -i inventory test.yml # --verbose
 
 echo "Testing idempotence based on functionality test"
 ansible-playbook -i inventory test.yml | tee "$OUTPUT_TEMP_FILE"

--- a/tasks/accessible.yml
+++ b/tasks/accessible.yml
@@ -2,32 +2,26 @@
 
 - include: clear_result.yml
 
-- block:
-    - name: "Host's ssh port is open from perspective of {{ accessible_wait_for_delegate }}"
-      wait_for:
-        host: "{{ ansible_host }}"
-        port: "{{ ansible_port | default(accessible_ssh_port) }}"
-        # Fail quickly == retry sooner
-        connect_timeout: 1
-        # Minumum is two-DNS failures + one second
-        timeout: "{{ accessible_retries | int * accessible_delay | int }}"
-        state: "started"
-      delegate_to: '{{ accessible_wait_for_delegate }}'
-      register: result
-      until: result | success
-      retries: '{{ accessible_retries }}'
-      delay: '{{ accessible_delay }}'
-      when: ansible_connection in accessible_ssh_types
+- name: "Host's ssh port is open from perspective of {{ accessible_wait_for_delegate }}"
+  wait_for:
+    host: "{{ ansible_host }}"
+    port: "{{ ansible_port | default(accessible_ssh_port) }}"
+    # Fail quickly == retry sooner
+    connect_timeout: 1
+    # Minumum is two-DNS failures + one second
+    timeout: "{{ accessible_retries | int * accessible_delay | int }}"
+    state: "started"
+  delegate_to: '{{ accessible_wait_for_delegate }}'
+  register: result
+  until: result is success
+  retries: '{{ accessible_retries }}'
+  delay: '{{ accessible_delay }}'
+  when: ansible_connection in accessible_ssh_types
 
-    - name: "Ansible accessability command executes successfully"
-      raw: '{{ accessible_cmd }}'  # raw has no subject-host dependencies
-      changed_when: False  # inspection only
-      register: result
-      until: result | success
-      retries: '{{ accessible_retries }}'
-      delay: '{{ accessible_delay }}'
-
-  rescue:
-    - name: "Failure result of accessible_cmd is debugged"
-      debug:
-        var: result.results[-1]  # Last one must have failed
+- name: "Ansible accessability command executes successfully"
+  raw: '{{ accessible_cmd }}'  # raw has no subject-host dependencies
+  changed_when: False  # inspection only
+  register: result
+  until: result is success
+  retries: '{{ accessible_retries }}'
+  delay: '{{ accessible_delay }}'

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,15 +1,13 @@
 ---
 
-- include: clear_result.yml
-
-- name: Host facts gather successfully when depds are already met.
+- name: Attempt to retrieve facts, ignoring any errors
   setup:
     gather_subset: min
-  failed_when: False
   ignore_errors: True
-  register: result
+  when: ansible_local is undefined
 
-- when: result is failed
+- when: ansible_local is undefined or
+        not ansible_local.accessible_deps_cmd_was_run | default(False, True) | bool
   block:
 
     - include: clear_result.yml
@@ -20,10 +18,24 @@
       when: accessible_os_name in accessible_ansible_deps and
             accessible_os_version in accessible_ansible_deps[accessible_os_name]
 
+    - name: The lookup result is debugged
+      debug: var=result
+
     - name: "Either the buffered command or the default is executed"
       raw: '{{ result | default(accessible_ansible_deps["default"], True) }}'
       when: accessible_ansible_deps["default"] | trim | length
+      register: result
 
-    - name: Host facts are gathered after dependencies satisfied
+    - name: The Ansible local-facts directory exists to record role-state.
+      file:
+        path: /etc/ansible/facts.d
+        state: directory
+
+    - name: The role-state is recorded
+      copy:
+        dest: /etc/ansible/facts.d/accessible_deps_cmd_was_run.fact
+        content: "true"
+
+    - name: Host facts are re-gathered after dependencies satisfied
       setup:
         gather_subset: '{{ accessible_gather_subset }}'

--- a/tasks/os_detection.yml
+++ b/tasks/os_detection.yml
@@ -28,3 +28,9 @@
     that:
         - 'accessible_os_name | trim | length'
         - 'accessible_os_version | trim | length'
+
+- name: The accessible_os_name and accessible_os_version values are debugged
+  debug:
+    msg: >
+        accessible_os_name '{{ accessible_os_name }}'
+        accessible_os_version '{{ accessible_os_version }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 
+result:
 accessible_os_name: ""
 accessible_os_version: ""
 accessible_ssh_port: "22"


### PR DESCRIPTION
The setup module cannot be relied upon to determine if subject-host
has had it's Ansible-dependencies installed, because they may have
been overridden.  Instead, use a local fact, deployed after running
the deps command.  This will keep the role idempotent.

Signed-off-by: Chris Evich <cevich@redhat.com>