### PR TITLE
Support multiple potential ssh ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 *.swp
 # Dropped during CI tests
 tests/ansible.cfg
-tests/roles/cevich.subscribed/
+tests/roles
+tests/ssh*key*
 # Downloaded during CI tests
 .travis_typo_check.sh
 tests/test_vault.yml

--- a/.travis.sh
+++ b/.travis.sh
@@ -12,7 +12,12 @@ chmod +x ./.travis_typo_check.sh
 
 cd tests
 curl -O https://raw.githubusercontent.com/cevich/subscribed/master/tests/test_vault.yml
-ansible-galaxy install --roles-path roles cevich.subscribed
+mkdir -p roles
+ansible-galaxy install --roles-path=$PWD/roles cevich.subscribed
+
+cd roles
+ln -sf ../../ cevich.accessible
+cd ..
 
 echo "Configuring vault"
 export ANSIBLE_VAULT_PASSWORD_FILE=$(mktemp -p '' .XXXXXXXX)
@@ -26,41 +31,76 @@ cleanup(){
     rm -rf roles/cevich.subscribed
     rm -f ../.travis_typo_check.sh
     rm -f test_vault.yml
+    rm -f ssh_private_key
     sudo $CONTAINER exec -i subtest /usr/sbin/subscription-manager unregister
     sudo $CONTAINER exec -i subtest /usr/sbin/subscription-manager clean
-    for name in subtest centos fedora ubuntu
+    for name in subtest centos fedora ubuntu foobar
     do
         sudo $CONTAINER rm -f $name
     done
 }
 trap cleanup EXIT
 
-mkdir -p roles
-cd roles
-ln -s ../../ cevich.accessible
-cd ..
-
 export ANSIBLE_CONFIG="$PWD/ansible.cfg"
-cat << EOF > ansible.cfg
+cat << EOF > $ANSIBLE_CONFIG
 [defaults]
+inventory = inventory.yml
+gathering = smart
 gather_subset = min
 vault_password_file = $ANSIBLE_VAULT_PASSWORD_FILE
 display_skipped_hosts = False
 any_errors_fatal = True
-deprecation_warnings = False
+host_key_checking = False
 force_color = 1
+no_target_syslog = True
+squash_actions = apk,apt,dnf,package,pacman,pkgng,yum,zypper
+retry_files_enabled = False
+
+[privilege_escalation]
+become=False
+become_user=root
+
+[ssh_connection]
+pipelining=True
+control_path = /tmp/ansible-%%n-%%p
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=publickey -o ConnectTimeout=13
 EOF
 
+sudo $CONTAINER run --detach --name "foobar" -p 22 lnterface/centos-ssh:latest &
 sudo $CONTAINER run --detach --name "subtest" docker.io/cevich/test_rhsm sleep 1h
 # Make subtest centos container pretend to be RHEL
 if [[ "$CONTAINER" == "podman" ]]
 then
-    mnt=$(podman mount subtest)
-    cp files/os-release $mnt/etc/os-release
-    podman umount subtest
+    mnt=$(sudo podman mount subtest)
+    sudo cp files/os-release $mnt/etc/os-release
+    sudo umount $mnt
 else
     sudo $CONTAINER cp ./files/os-release subtest:/etc/os-release
 fi
+
+# setup the ssh key access
+curl -o ssh_private_key https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant
+curl -o ssh_private_key.pub https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub
+chmod 600 ssh_private_key*
+
+wait
+if [[ "$CONTAINER" == "podman" ]]
+then
+    mnt=$(sudo podman mount foobar)
+    sudo mkdir "$mnt/root/.ssh"
+    sudo cp ssh_private_key.pub "$mnt/root/.ssh/authorized_keys"
+    sudo chown -R root.root "$mnt/root/.ssh"
+    sudo chmod 700 "$mnt/root/.ssh"
+    sudo chmod 600 "$mnt/root/.ssh/authorized_keys"
+    sudo umount $mnt
+else
+    sudo $CONTAINER exec foobar mkdir /root/.ssh
+    sudo $CONTAINER cp ssh_private_key.pub foobar:/root/.ssh/authorized_keys
+    sudo $CONTAINER exec foobar chown -R root.root "/root/.ssh"
+    sudo $CONTAINER exec foobar chmod 700 "/root/.ssh"
+    sudo $CONTAINER exec foobar chmod 600 "/root/.ssh/authorized_keys"
+fi
+export FOOBAR_PORT="$(sudo $CONTAINER port foobar 22 | cut -d : -f 2)"
 
 (
     set +abefhkmnptuvxBCEHPT
@@ -69,21 +109,20 @@ fi
 unset -v ANSIBLE_VAULT_PASSWORD
 
 echo "Testing syntax"
-ansible-playbook -i inventory test.yml --verbose --syntax-check
+ansible-playbook test.yml -e foobar_port=$FOOBAR_PORT --verbose --syntax-check
 
 # Check wait-for-available functionality, assuming pulling these images
 # will take a few moments more that starting the playbook run.
 for name in centos fedora ubuntu
 do
-    sudo $CONTAINER rmi docker.io/$name || true
-    sudo $CONTAINER run --detach --name "$name" docker.io/$name sleep 1h &> "$OUTPUT_TEMP_FILE" &
+    sleep 30s && sudo $CONTAINER run --detach --name "$name" docker.io/$name sleep 1h &
 done
 
 echo "Testing functionality"
-ansible-playbook -i inventory test.yml # --verbose
+ansible-playbook -e foobar_port=$FOOBAR_PORT test.yml --verbose
 
 echo "Testing idempotence based on functionality test"
-ansible-playbook -i inventory test.yml | tee "$OUTPUT_TEMP_FILE"
+ansible-playbook -e foobar_port=$FOOBAR_PORT test.yml | tee "$OUTPUT_TEMP_FILE"
 grep -q 'changed=0.*failed=0'  "$OUTPUT_TEMP_FILE" \
     && (echo 'Idempotence test: pass' && exit 0) \
     || (echo 'Idempotence test: fail' && exit 1)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,16 +3,27 @@
 # When successful, this command signals the subject host is ready for further commands
 accessible_cmd: '/bin/true'
 
-# The number of times to retry accessible_cmd before failing subject host
-accessible_retries: 20
+# The number of times to retry open port and accessible_cmd before failing
+# Must be at least 1
+accessible_retries: 10
 
-# The amount of time between retries to wait
-accessible_delay: 5
+# The number of seconds to wait between open-port and accessible_cmd checks
+# Must be at least 13 (two DNS failures + one second)
+accessible_delay: 13
 
-# Table of command(s) that will install ansible dependencies depending on os type and version
-_typ_rhel_deps: 'libselinux-python policycoreutils-python rsync'
-_typ_fed_deps: 'python-simplejson python2-dnf libselinux-python python2-policycoreutils rsync'
-_typ_deb_deps: 'python python-simplejson rsync'
+# A single, or a list of network ports to confirm as open.
+# If a list is given, only one port must open within
+# accessible_retries * accessible_delay seconds
+accessible_ssh_port: "22"
+
+# Inventory host (or "localhost") with network visibility to role-subject host
+accessible_wait_for_delegate: "localhost"
+
+# When true, update the value of ansible_port to first-found open port
+accessible_set_ansible_port: True
+
+# Table of command(s) that will install ansible dependencies depending on OS type and version
+# For special cases, simply override entire dict, only populating ``default`` for a host.
 accessible_ansible_deps:
     default: "python --version"
     rhel:
@@ -29,5 +40,4 @@ accessible_ansible_deps:
         "18": 'apt-get -qq update && apt-get -qq install {{ _typ_deb_deps }}'
 
 # String to use for 'gather_subset' argument to setup module
-accessible_gather_subset: 'network'
-
+accessible_gather_subset: 'min'

--- a/files/wait_for.sh
+++ b/files/wait_for.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+die(){
+    echo "$2" &> /dev/stderr
+    exit $1
+}
+
+[[ "$#" -ge "4" ]] || die 6 "Usage: $(basename $0) <retries> <delay> <host> <port> [port]..."
+[[ -n "$(type -P ncat || type -P nc)" ]] || die 7 "Either the ncat or nc executable is required"
+
+RETRIES=$1
+shift
+DELAY=$1
+shift
+HOST=$1
+shift
+PORTS=$@
+
+TIMEOUT="$[$RETRIES * $DELAY + 1]"
+
+for (( i=0 ; i < $RETRIES ; i++ ));
+do
+    for port in $PORTS
+    do
+        if "$(type -P ncat || type -P nc)" -z "$HOST" "$port"
+        then
+            echo "Try $i: $HOST:$port OPEN" > /dev/stderr
+            echo "$port" > /dev/stdout
+            exit 0
+        else
+            echo "Try $i: $HOST:$port CLOSED" > /dev/stderr
+        fi
+    done
+    sleep "$DELAY"
+done
+echo "Retries exceeded looking for open port" > /dev/stderr
+exit 1

--- a/tasks/accessible.yml
+++ b/tasks/accessible.yml
@@ -1,27 +1,38 @@
 ---
 
-- include: clear_result.yml
+- name: 'Accessible tasks expectations are met'
+  assert:
+    that:
+        - 'accessible_cmd is string'
+        - 'accessible_retries | int > 0'
+        - 'accessible_delay | int > 12'
+        - 'accessible_wait_for_delegate == "localhost" or
+           accessible_wait_for_delegate in hostvars | list'
+        - 'accessible_ansible_deps is mapping'
+        - 'accessible_gather_subset is string'
+        - 'ansible_connection | trim in accessible_ssh_types'
 
-- name: "Host's ssh port is open from perspective of {{ accessible_wait_for_delegate }}"
-  wait_for:
-    host: "{{ ansible_host }}"
-    port: "{{ ansible_port | default(accessible_ssh_port) }}"
-    # Fail quickly == retry sooner
-    connect_timeout: 1
-    # Minumum is two-DNS failures + one second
-    timeout: "{{ accessible_retries | int * accessible_delay | int }}"
-    state: "started"
-  delegate_to: '{{ accessible_wait_for_delegate }}'
-  register: result
-  until: result is success
-  retries: '{{ accessible_retries }}'
-  delay: '{{ accessible_delay }}'
-  when: ansible_connection in accessible_ssh_types
+- include_tasks: clear_result.yml
 
-- name: "Ansible accessability command executes successfully"
-  raw: '{{ accessible_cmd }}'  # raw has no subject-host dependencies
-  changed_when: False  # inspection only
+- name: Script command is formed for checking multiple ports
+  set_fact:
+    result: 'wait_for.sh {{ accessible_retries | int }} {{ accessible_delay | int }} {{ ansible_host }} {{ accessible_ssh_port | join (" ") }}'
+  when: not accessible_ssh_port is string and
+        not accessible_ssh_port is mapping and
+            accessible_ssh_port is sequence
+
+- name: Script command is formed to checking on a single port
+  set_fact:
+    result: 'wait_for.sh {{ accessible_retries | int }} {{ accessible_delay | int }} {{ ansible_host }} {{ accessible_ssh_port | int }}'
+  when: not result | default("", True) | trim | length
+
+- name: 'Wait for a port to open or timeout using a script'
+  script: '{{ result }}'
+  delegate_to: "{{ accessible_wait_for_delegate }}"
+  changed_when: False
   register: result
-  until: result is success
-  retries: '{{ accessible_retries }}'
-  delay: '{{ accessible_delay }}'
+
+- name: 'The first found open port is set as ansible_port for this host'
+  set_fact:
+    ansible_port: '{{ result.stdout | trim | int }}'
+  when: accessible_set_ansible_port | bool

--- a/tasks/accessible_test_command.yml
+++ b/tasks/accessible_test_command.yml
@@ -1,0 +1,11 @@
+---
+
+- include: clear_result.yml
+
+- name: "Ansible accessability command executes successfully"
+  raw: '{{ accessible_cmd }}'  # raw has no subject-host dependencies
+  changed_when: False  # inspection only
+  register: result
+  until: result is success
+  retries: '{{ accessible_retries }}'
+  delay: '{{ accessible_delay }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
 
-- include: accessible.yml
+- include_tasks: accessible.yml
+  when: ansible_connection | trim in accessible_ssh_types
 
-- include: os_detection.yml
+- include_tasks: accessible_test_command.yml
+
+- include_tasks: os_detection.yml
 
 - name: RHEL hosts apply the cevich.subscribed role before installing dependencies
   import_role:

--- a/tasks/os_detection.yml
+++ b/tasks/os_detection.yml
@@ -14,13 +14,13 @@
 - name: "The accessible_os_name fact is defined from temporary buffer contents"
   set_fact:
     accessible_os_name: '{{ item | regex_replace("^ID=\W*(\w+)\W*", "\1") }}'
-  when: not accessible_os_name | trim | length and item | search('^ID=')
+  when: not accessible_os_name | trim | length and item is search('^ID=')
   with_items: '{{ result }}'
 
 - name: "The accessible_os_version fact is defined from temporary buffer contents"
   set_fact:
     accessible_os_version: '{{ item | regex_replace("^VERSION_ID=\D*([0-9]+).*", "\1") }}'
-  when: not accessible_os_version | trim | length and item | search('^VERSION_ID=')
+  when: not accessible_os_version | trim | length and item is search('^VERSION_ID=')
   with_items: '{{ result }}'
 
 - name: "Both accessible_os_name and accessible_os_version are non-empty"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,4 +1,0 @@
-subtest ansible_connection=docker ansible_host=subtest
-centos ansible_connection=docker ansible_host=centos
-fedora ansible_connection=docker ansible_host=fedora
-ubuntu ansible_connection=docker ansible_host=ubuntu

--- a/tests/inventory.yml
+++ b/tests/inventory.yml
@@ -1,0 +1,29 @@
+---
+
+all:
+    hosts:
+        subtest: {}
+        centos: {}
+        fedora: {}
+        ubuntu: {}
+        foobar:
+            ansible_host: 127.0.0.1
+            ansible_user: root
+            ansible_ssh_private_key_file: '{{ playbook_dir }}/ssh_private_key'
+            accessible_ssh_port:
+                - 11238
+                - 11236
+                - 11235
+                - "{{ foobar_port | int }}"
+                - 11237
+                - 11234
+    children:
+        containers:
+            hosts:
+                subtest:
+                centos:
+                fedora:
+                ubuntu:
+            vars:
+                ansible_connection: docker
+                ansible_host: "{{ inventory_hostname }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,10 +2,28 @@
 
 - hosts: all
   gather_facts: False
-  strategy: linear
   vars_files:
     - '{{ playbook_dir }}/test_vault.yml'
   roles:
     - role: cevich.accessible
       vars:
         rhsm: '{{ _vault_rhsm if ansible_host == "subtest" else {} }}'
+
+- hosts: foobar
+  gather_facts: False
+  tasks:
+    - assert: that='ansible_port == foobar_port'
+
+# Verify wait_for.sh works with a single port
+- hosts: foobar
+  gather_facts: False
+  vars_files:
+    - '{{ playbook_dir }}/test_vault.yml'
+  vars:
+    accessible_ssh_port: "{{ foobar_port | int }}"
+
+  roles:
+    - role: cevich.accessible
+
+  post_tasks:
+    - assert: that='ansible_port == foobar_port'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,12 @@
 result:
 accessible_os_name: ""
 accessible_os_version: ""
-accessible_ssh_port: "22"
 accessible_ssh_types: ['smart', 'ssh', 'paramiko']
-accessible_wait_for_delegate: "localhost"
+
+# Shortcuts for accessible_ansible_deps values for common distros
+_typ_rhel_deps: 'libselinux-python policycoreutils-python rsync'
+_typ_fed_deps: 'python-simplejson python2-dnf libselinux-python python2-policycoreutils rsync'
+_typ_deb_deps: 'python python-simplejson rsync'
+
+_accessible_ssh_ports: []
+_accessible_async_results: []


### PR DESCRIPTION
The "in production" or "initial setup" state of target hosts isn't
always known from the network-perspective of the control-host.
This can lead to some inventory-ambiguity over which port should
be utilized for ssh access to subject-hosts.

For example, a bastion host may have an alternate/non-standard ssh port
number, but only after it's fully configured and placed in production.

Support this use-case with this role, by accepting a list of possible
ssh ports for consideration.  Monitor, and select the first one that
opens up for use.  Assuming the test command is successful, optionally
allow setting ``ansible_port`` for the remainder of the play, for this
host.

Update CI tests to verify this port-searching behavior is functional.

Signed-off-by: Chris Evich <cevich@redhat.com>